### PR TITLE
Don't log command if it is nil

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -27,7 +27,10 @@ func Destroy(c *cli.Context) {
 
 func FatalIf(c *cmd.Cmd, err error) {
 	if err != nil {
-		cli.ShowCommandHelp(c.Context, c.Name)
+		if c != nil {
+			cli.ShowCommandHelp(c.Context, c.Name)
+		}
+		
 		println("ERROR:\n   ", err.Error())
 		os.Exit(1)
 	}


### PR DESCRIPTION
If I incorrectly run the gh-release command like this:

``` sh
gh-release --token <token> create --release_path "test"
```

It will panic with the following error:

``` sh
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x10 pc=0x400dba]

goroutine 1 [running]:
runtime.panic(0x6c8c60, 0xa856c8)
        /usr/lib/go/src/pkg/runtime/panic.c:266 +0xb6
main.FatalIf(0x0, 0x7f4b9f872e80, 0xc210042a20)
        /home/igor/go/src/github.com/rastasheep/gh-release/commands.go:30 +0x2a
main.Create(0xc210044460)
        /home/igor/go/src/github.com/rastasheep/gh-release/commands.go:13 +0x4e
github.com/codegangsta/cli.Command.Run(0x730400, 0x6, 0x72fc80, 0x1, 0x0, ...)
        /home/igor/go/src/github.com/codegangsta/cli/command.go:118 +0xe32
github.com/codegangsta/cli.(*App).Run(0xc210065000, 0xc21000a000, 0x6, 0x6, 0x0, ...)
        /home/igor/go/src/github.com/codegangsta/cli/app.go:154 +0x9da
main.main()
        /home/igor/go/src/github.com/rastasheep/gh-release/main.go:57 +0x122
```

After the fix, it will display the following correct error:

``` sh
ERROR:
    You must provide repository name and release version.
```
